### PR TITLE
Add sample users as seed data with different permissions

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,7 +1,21 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
+# Seed database depending on the environment:
+case Rails.env
+when "development"
+  # env == "development":
+  profile1 = Profile.create!(:full_name => "John Doe", :nick_name => "johndoe", :email => "johndoe@civictech.ro",
+                             :flags => 0x1 & 0x2 & 0x4 & 0x8)
+  profile2 = Profile.create!(:full_name => "Coordinator", :nick_name => "coordinator",
+                             :email => "coordinator@civictech.ro", :flags => 0x8)
+  profile3 = Profile.create!(:full_name => "Fellow", :nick_name => "fellow", :email => "fellow@civictech.ro",
+                             :flags => 0x4)
+  profile4 = Profile.create!(:full_name => "Volunteer", :nick_name => "volunteer", :email => "volunteer@civictech.ro",
+                             :flags => 0x2)
+  profile5 = Profile.create!(:full_name => "Applicant", :nick_name => "applicant", :email => "applicant@civictech.ro",
+                             :flags => 0x1)
+  
+  User.create(:email => profile1.email, :password => "fKL9UeKSkH4CtA")
+  User.create(:email => profile2.email, :password => "91WjtWiNA6BjhQ")
+  User.create(:email => profile3.email, :password => "tsU3kZlnawTJ2Q")
+  User.create(:email => profile4.email, :password => "90s7hD23vrjvKw")
+  User.create(:email => profile5.email, :password => "m9dZmxPQfAsv8w")
+end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ case Rails.env
 when "development"
   # env == "development":
   profile1 = Profile.create!(:full_name => "John Doe", :nick_name => "johndoe", :email => "johndoe@civictech.ro",
-                             :flags => 0x1 & 0x2 & 0x4 & 0x8)
+                             :flags => 0xF) # (0x1 | 0x2 | 0x4 | 0x8; all flags)
   profile2 = Profile.create!(:full_name => "Coordinator", :nick_name => "coordinator",
                              :email => "coordinator@civictech.ro", :flags => 0x8)
   profile3 = Profile.create!(:full_name => "Fellow", :nick_name => "fellow", :email => "fellow@civictech.ro",


### PR DESCRIPTION
I've added some sample users for developer's ease to login on the platform when setting up locally.

Using `rake db:seed` on the development environment, it creates 5 users and the afferent profiles with different permissions, and some random passwords.