### PR TITLE
Create a permission_error page for permission related messages

### DIFF
--- a/app/controllers/concerns/login_concern.rb
+++ b/app/controllers/concerns/login_concern.rb
@@ -111,7 +111,8 @@ module LoginConcern
   module ClassMethods
     def authorization_required(required_level = USER_LEVEL_FELLOW, opts={})
       before_action opts do
-        redirect_to login_path, notice: 'Higher level authorization is required to access requested resource' if !is_user_logged_in? or !is_user_level_authorized?(required_level)
+        redirect_to login_path, notice: 'You must be logged in to access requested resource.' if !is_user_logged_in?
+        redirect_to permission_error_path if !is_user_level_authorized?(required_level)
       end
     end
   end

--- a/app/views/static/permission_error.html.erb
+++ b/app/views/static/permission_error.html.erb
@@ -1,0 +1,12 @@
+<div class="container">
+  <div class="row">
+    <div class="col-lg-6 col-lg-offset-3">
+      <%= render partial: 'shared/notice' %>
+      <div class="login-form panel panel-default text-center">
+	Higher level permissions are required to access the requested resource.
+        <br /><br />
+        <%= link_to "Click here to go back.", :back %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
     get 'me', to: 'redirect#me'
     get '/login', to: 'static#login'
     post '/login', to: 'static#login_post'
+    get '/permission_error', to: 'static#permission_error'
     post '/123contacts_signup', to: 'static#contacts_signup'
     get 'httpsify', to: 'static#httpsify'
 

--- a/spec/requests/meetings_spec.rb
+++ b/spec/requests/meetings_spec.rb
@@ -47,22 +47,22 @@ RSpec.describe "Meetings", type: :request do
       end
       it 'cannot GET' do
         get_helpers(meeting) do |url|
-          # must re-login for each case
+          # permissions invalid
           login :volunteer
           get url, https
-          expect(response).to redirect_to(login_path)
+          expect(response).to redirect_to(permission_error_path)
         end
       end
       it 'cannot DELETE' do 
         expect {
           delete meeting_path(meeting), https
-          expect(response).to redirect_to(login_path)
+          expect(response).to redirect_to(permission_error_path)
         }.not_to change(Meeting, :count)
       end
       it "cannot POST" do
         expect {
           post meetings_path, https
-          expect(response).to redirect_to(login_path)
+          expect(response).to redirect_to(permission_error_path)
         }.not_to change(Meeting, :count)
       end
     end


### PR DESCRIPTION
Related to issue #22, instead of logging of the users anytime
there is a permission issue, now the user will be redirected
to a permission_error page that does not log him off.

If the user was not logged in in the first place, the behavior
is not changed, the user will be redirected to the login page
with a relevant message instead.